### PR TITLE
Implement browsing tabs and upload progress

### DIFF
--- a/src/features/auth/withTokenRefresh.js
+++ b/src/features/auth/withTokenRefresh.js
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { refreshSession, setAuthState } from './authSlice';
 
 const withTokenRefresh = (WrappedComponent) => {
-    return (props) => {
+    const Component = (props) => {
         const dispatch = useDispatch();
 
         useEffect(() => {
@@ -16,6 +16,8 @@ const withTokenRefresh = (WrappedComponent) => {
 
         return <WrappedComponent {...props} />;
     };
+    Component.displayName = `withTokenRefresh(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+    return Component;
 };
 
 export default withTokenRefresh;

--- a/src/hoc/withAuth.js
+++ b/src/hoc/withAuth.js
@@ -5,7 +5,7 @@ import { gql, useLazyQuery } from '@apollo/client';
 import { setAuthState } from '../features/auth/authSlice';
 
 const withAuth = (WrappedComponent) => {
-    return (props) => {
+    const Component = (props) => {
         const [loading, setLoading] = useState(true);
         const router = useRouter();
         const dispatch = useDispatch();
@@ -60,6 +60,8 @@ const withAuth = (WrappedComponent) => {
 
         return <WrappedComponent {...props} />;
     };
+    Component.displayName = `withAuth(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+    return Component;
 };
 
 export default withAuth;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { gql, useQuery } from '@apollo/client';
-import { Button, Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import { Button, Card, CardContent, CardMedia, Grid, Typography, Tabs, Tab } from '@mui/material';
 import Link from 'next/link';
 import Navbar from '../components/Navbar';
 import withAuth from '../hoc/withAuth';
@@ -16,8 +16,62 @@ const LIST_VIDEOS_QUERY = gql`
     }
 `;
 
+const LIST_MUSIC_QUERY = gql`
+    query listMusic($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
+        listMusic(filter: $filter, pagination: $pagination, sorting: $sorting) {
+            id
+            title
+            url
+            thumbnail
+        }
+    }
+`;
+
+const LIST_PICTURES_QUERY = gql`
+    query listPictures($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
+        listPictures(filter: $filter, pagination: $pagination, sorting: $sorting) {
+            id
+            title
+            url
+            thumbnail
+        }
+    }
+`;
+
+const LIST_DOCUMENTS_QUERY = gql`
+    query listDocuments($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
+        listDocuments(filter: $filter, pagination: $pagination, sorting: $sorting) {
+            id
+            title
+            url
+            thumbnail
+        }
+    }
+`;
+
+const LIST_OTHER_FILES_QUERY = gql`
+    query listOtherFiles($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
+        listOtherFiles(filter: $filter, pagination: $pagination, sorting: $sorting) {
+            id
+            title
+            url
+            thumbnail
+        }
+    }
+`;
+
+const queries = {
+    videos: { query: LIST_VIDEOS_QUERY, field: 'listVideos' },
+    music: { query: LIST_MUSIC_QUERY, field: 'listMusic' },
+    pictures: { query: LIST_PICTURES_QUERY, field: 'listPictures' },
+    documents: { query: LIST_DOCUMENTS_QUERY, field: 'listDocuments' },
+    other: { query: LIST_OTHER_FILES_QUERY, field: 'listOtherFiles' },
+};
+
 function Home() {
-    const { loading, error, data } = useQuery(LIST_VIDEOS_QUERY);
+    const [category, setCategory] = useState('videos');
+    const { query, field } = queries[category];
+    const { loading, error, data } = useQuery(query);
     const [isClient, setIsClient] = useState(false);
 
     useEffect(() => {
@@ -29,13 +83,20 @@ function Home() {
     }
 
     if (loading) return <Typography>Loading...</Typography>;
-    if (error) return <Typography>Error loading videos</Typography>;
+    if (error) return <Typography>Error loading media</Typography>;
 
     return (
         <div>
             <Navbar />
+            <Tabs value={category} onChange={(e, val) => setCategory(val)} centered sx={{ mb: 2 }}>
+                <Tab label="Videos" value="videos" />
+                <Tab label="Music" value="music" />
+                <Tab label="Pictures" value="pictures" />
+                <Tab label="Documents" value="documents" />
+                <Tab label="Other" value="other" />
+            </Tabs>
             <Grid container spacing={2}>
-                {data.listVideos.map((item) => (
+                {data && data[field].map((item) => (
                     <Grid item xs={12} sm={6} md={4} key={item.id}>
                         <Card>
                             <CardMedia

--- a/src/pages/upload.js
+++ b/src/pages/upload.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
     Button,
+    CircularProgress,
     Container,
     FormControl,
     FormControlLabel,
@@ -28,7 +29,7 @@ function UploadMedia() {
     const [mimetype, setMimetype] = useState('');
     const [thumbnail, setThumbnail] = useState('');
     const [adminOnly, setAdminOnly] = useState(false);
-    const [createMedia] = useMutation(CREATE_MEDIA_MUTATION);
+    const [createMedia, { loading }] = useMutation(CREATE_MEDIA_MUTATION);
 
     const handleUpload = async () => {
         try {
@@ -102,9 +103,10 @@ function UploadMedia() {
                     }
                     label="Admin Only"
                 />
-                <Button variant="contained" color="primary" onClick={handleUpload}>
-                    Upload
+                <Button variant="contained" color="primary" onClick={handleUpload} disabled={loading}>
+                    {loading ? 'Uploading...' : 'Upload'}
                 </Button>
+                {loading && <CircularProgress size={24} sx={{ ml: 2 }} />}
             </Container>
         </div>
     );


### PR DESCRIPTION
## Summary
- add display names to auth HOCs for linting
- show file category tabs on home page for improved browsing
- show a progress indicator during media uploads

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687932eda570832989c8e44c55015d27