### PR TITLE
Update client GraphQL calls to match protocol

### DIFF
--- a/src/hoc/withAuth.js
+++ b/src/hoc/withAuth.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useDispatch, useSelector } from 'react-redux';
-import { gql, useLazyQuery } from '@apollo/client';
+import { gql, useMutation } from '@apollo/client';
 import { setAuthState } from '../features/auth/authSlice';
 
 const withAuth = (WrappedComponent) => {
@@ -12,23 +12,25 @@ const withAuth = (WrappedComponent) => {
         const { sessionToken } = useSelector((state) => state.auth);
 
         const REFRESH_SESSION = gql`
-            query refreshSession {
-                refreshSession {
-                    userId
-                    sessionId
-                    username
-                    avatarPicture
-                    sessionToken
-                    sessionExpireDateTime
-                    admin
+            mutation refreshSession {
+                auth {
+                    refreshSession {
+                        userId
+                        sessionId
+                        username
+                        avatarPicture
+                        sessionToken
+                        sessionExpireDateTime
+                        admin
+                    }
                 }
             }
         `;
 
-        const [refreshSessionQuery, { data }] = useLazyQuery(REFRESH_SESSION, {
+        const [refreshSessionMutation, { data }] = useMutation(REFRESH_SESSION, {
             onCompleted: (data) => {
-                if (data && data.refreshSession) {
-                    dispatch(setAuthState(data.refreshSession));
+                if (data && data.auth && data.auth.refreshSession) {
+                    dispatch(setAuthState(data.auth.refreshSession));
                     setLoading(false);
                 } else {
                     router.push('/login');
@@ -44,7 +46,7 @@ const withAuth = (WrappedComponent) => {
                     return;
                 }
                 try {
-                    await refreshSessionQuery();
+                    await refreshSessionMutation();
                 } catch (error) {
                     router.push('/login');
                 }
@@ -52,7 +54,7 @@ const withAuth = (WrappedComponent) => {
             if (typeof window !== 'undefined') {
                 checkAuth();
             }
-        }, [refreshSessionQuery, router]);
+        }, [refreshSessionMutation, router]);
 
         if (loading) {
             return <p>Loading...</p>; // or a loading spinner

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -7,55 +7,65 @@ import withAuth from '../hoc/withAuth';
 
 const LIST_VIDEOS_QUERY = gql`
     query listVideos($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
-        listVideos(filter: $filter, pagination: $pagination, sorting: $sorting) {
-            id
-            title
-            url
-            thumbnail
+        lists {
+            listVideos(filter: $filter, pagination: $pagination, sorting: $sorting) {
+                id
+                title
+                url
+                thumbnail
+            }
         }
     }
 `;
 
 const LIST_MUSIC_QUERY = gql`
     query listMusic($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
-        listMusic(filter: $filter, pagination: $pagination, sorting: $sorting) {
-            id
-            title
-            url
-            thumbnail
+        lists {
+            listMusic(filter: $filter, pagination: $pagination, sorting: $sorting) {
+                id
+                title
+                url
+                thumbnail
+            }
         }
     }
 `;
 
 const LIST_PICTURES_QUERY = gql`
     query listPictures($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
-        listPictures(filter: $filter, pagination: $pagination, sorting: $sorting) {
-            id
-            title
-            url
-            thumbnail
+        lists {
+            listPictures(filter: $filter, pagination: $pagination, sorting: $sorting) {
+                id
+                title
+                url
+                thumbnail
+            }
         }
     }
 `;
 
 const LIST_DOCUMENTS_QUERY = gql`
     query listDocuments($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
-        listDocuments(filter: $filter, pagination: $pagination, sorting: $sorting) {
-            id
-            title
-            url
-            thumbnail
+        lists {
+            listDocuments(filter: $filter, pagination: $pagination, sorting: $sorting) {
+                id
+                title
+                url
+                thumbnail
+            }
         }
     }
 `;
 
 const LIST_OTHER_FILES_QUERY = gql`
     query listOtherFiles($filter: MediaFilter, $pagination: Pagination, $sorting: Sorting) {
-        listOtherFiles(filter: $filter, pagination: $pagination, sorting: $sorting) {
-            id
-            title
-            url
-            thumbnail
+        lists {
+            listOtherFiles(filter: $filter, pagination: $pagination, sorting: $sorting) {
+                id
+                title
+                url
+                thumbnail
+            }
         }
     }
 `;
@@ -85,6 +95,8 @@ function Home() {
     if (loading) return <Typography>Loading...</Typography>;
     if (error) return <Typography>Error loading media</Typography>;
 
+    const items = data?.lists ? data.lists[field] : [];
+
     return (
         <div>
             <Navbar />
@@ -96,7 +108,7 @@ function Home() {
                 <Tab label="Other" value="other" />
             </Tabs>
             <Grid container spacing={2}>
-                {data && data[field].map((item) => (
+                {items.map((item) => (
                     <Grid item xs={12} sm={6} md={4} key={item.id}>
                         <Card>
                             <CardMedia

--- a/src/pages/editMedia.js
+++ b/src/pages/editMedia.js
@@ -16,22 +16,26 @@ import { useRouter } from 'next/router';
 import Navbar from '../components/Navbar';
 
 const GET_MEDIA_BY_ID_QUERY = gql`
-    query getMediaById($id: Int!) {
-        getMediaById(id: $id) {
-            id
-            title
-            url
-            mimetype
-            thumbnail
-            adminOnly
+    query getMediaById($id: ID!) {
+        gets {
+            getMediaById(id: $id) {
+                id
+                title
+                url
+                mimetype
+                thumbnail
+                adminOnly
+            }
         }
     }
 `;
 
 const EDIT_MEDIA_MUTATION = gql`
     mutation editMedia($input: EditMediaInput!) {
-        editMedia(input: $input) {
-            id
+        media {
+            editMedia(input: $input) {
+                id
+            }
         }
     }
 `;
@@ -52,7 +56,7 @@ function EditMedia() {
 
     useEffect(() => {
         if (data) {
-            const media = data.getMediaById;
+            const media = data.gets.getMediaById;
             setTitle(media.title);
             setUrl(media.url);
             setMimetype(media.mimetype);

--- a/src/pages/media/[id].js
+++ b/src/pages/media/[id].js
@@ -5,13 +5,15 @@ import { Button, Container, Typography } from '@mui/material';
 import Navbar from '../../components/Navbar';
 
 const GET_MEDIA_BY_ID_QUERY = gql`
-    query getMediaById($id: Int!) {
-        getMediaById(id: $id) {
-            id
-            title
-            url
-            mimetype
-            thumbnail
+    query getMediaById($id: ID!) {
+        gets {
+            getMediaById(id: $id) {
+                id
+                title
+                url
+                mimetype
+                thumbnail
+            }
         }
     }
 `;
@@ -26,7 +28,7 @@ function MediaDetails() {
     if (loading) return <Typography>Loading...</Typography>;
     if (error) return <Typography>Error loading media</Typography>;
 
-    const media = data.getMediaById;
+    const media = data.gets.getMediaById;
 
     return (
         <div>

--- a/src/pages/upload.js
+++ b/src/pages/upload.js
@@ -17,8 +17,10 @@ import Navbar from '../components/Navbar';
 
 const CREATE_MEDIA_MUTATION = gql`
     mutation createMedia($input: CreateMediaInput!) {
-        createMedia(input: $input) {
-            id
+        media {
+            createMedia(input: $input) {
+                id
+            }
         }
     }
 `;


### PR DESCRIPTION
## Summary
- update GraphQL login and refresh session logic to use nested mutations
- adjust token refresh HOC to call mutation
- modify media listing and detail queries to use `lists`/`gets`
- update media create and edit mutations to use `media` group
- update GraphQL queries across pages accordingly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a73e151188329bd5d81c583809bb7