### PR TITLE
Integrate file server protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ npm run dev
 
 The app will be available at [http://localhost:3000](http://localhost:3000). GraphQL requests are proxied to `http://localhost:4000/graphql` as configured in `next.config.mjs`.
 
+### File server
+
+Raw file data is handled by the separate `storage-file-server-2` REST API. By default the client expects this service to run at `http://localhost:3500`. Set `NEXT_PUBLIC_FILE_SERVER_URL` to override the URL if required.
+
+Uploading a file happens in two steps:
+
+1. A media record is created through the GraphQL mutation `createMedia`.
+2. The selected file is sent to `POST /media/upload` with the user's `sessionToken` and the created `mediaId` as described in `docs/FILE_SERVER_PROTOCOL.md`.
+
+Files are downloaded via `GET /media/:id/download`.
+
 To build for production run:
 
 ```bash

--- a/src/lib/fileServerApi.js
+++ b/src/lib/fileServerApi.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+const BASE_URL = process.env.NEXT_PUBLIC_FILE_SERVER_URL || 'http://localhost:3500';
+
+export async function uploadFile({ sessionToken, mediaId, fileContent, mimeType }) {
+    const response = await axios.post(`${BASE_URL}/media/upload`, {
+        sessionToken,
+        mediaId,
+        fileContent,
+        mimeType,
+    });
+    return response.data;
+}
+
+export function downloadUrl(mediaId) {
+    return `${BASE_URL}/media/${mediaId}/download`;
+}
+
+export async function deleteFile(mediaId) {
+    await axios.delete(`${BASE_URL}/media/${mediaId}`);
+}
+
+export async function fetchMetadata(mediaId) {
+    const response = await axios.get(`${BASE_URL}/media/${mediaId}/metadata`);
+    return response.data;
+}
+

--- a/src/pages/media/[id].js
+++ b/src/pages/media/[id].js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { gql, useQuery } from '@apollo/client';
 import { Button, Container, Typography } from '@mui/material';
 import Navbar from '../../components/Navbar';
+import { downloadUrl } from '../../lib/fileServerApi';
 
 const GET_MEDIA_BY_ID_QUERY = gql`
     query getMediaById($id: ID!) {
@@ -37,18 +38,18 @@ function MediaDetails() {
                 <Typography variant="h4" gutterBottom>{media.title}</Typography>
                 {media.mimetype.startsWith('video/') && (
                     <video width="100%" controls>
-                        <source src={media.url} type={media.mimetype} />
+                        <source src={downloadUrl(media.id)} type={media.mimetype} />
                         Your browser does not support the video tag.
                     </video>
                 )}
                 {media.mimetype.startsWith('audio/') && (
                     <audio controls>
-                        <source src={media.url} type={media.mimetype} />
+                        <source src={downloadUrl(media.id)} type={media.mimetype} />
                         Your browser does not support the audio element.
                     </audio>
                 )}
                 {!media.mimetype.startsWith('video/') && !media.mimetype.startsWith('audio/') && (
-                    <Button variant="contained" color="primary" href={media.url} download>
+                    <Button variant="contained" color="primary" href={downloadUrl(media.id)} download>
                         Download
                     </Button>
                 )}


### PR DESCRIPTION
## Summary
- add file server API wrapper
- upload files via `POST /media/upload`
- download media via file server
- document file server usage in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a7975252083299fdd707cd87b3a0c